### PR TITLE
Added option to pass the 'arguments' option to the 'maven-jarsigner-plugin' plugin

### DIFF
--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/sign/SignConfig.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/sign/SignConfig.java
@@ -137,6 +137,11 @@ public class SignConfig
     private String tsaLocation;
 
     /**
+     * Provides custom arguements to pass to the signtool.
+     */
+    private String[] arguments;
+
+    /**
      * Called before any Jars get signed or verified.
      * <p/>
      * This method allows you to create any keys or perform any initialisation that the
@@ -212,6 +217,7 @@ public class SignConfig
         request.setArchive( jarToSign );
         request.setSignedjar( signedJar );
         request.setTsaLocation( getTsaLocation() );
+        request.setArguments( getArguments() );
         return request;
     }
 
@@ -383,6 +389,11 @@ public class SignConfig
         this.tsaLocation = tsaLocation;
     }
 
+    public void setArguments(String[] arguments)
+    {
+        this.arguments = arguments;
+    }
+
     public String getKeystore()
     {
         return keystore;
@@ -476,6 +487,11 @@ public class SignConfig
     public String getMaxMemory()
     {
         return maxMemory;
+    }
+
+    public String[] getArguments()
+    {
+        return arguments;
     }
 
     public String getDname()


### PR DESCRIPTION
The maven jarsigner plugin has an attribute called 'arguments' to relay custom arguments to signtool. This patch adds the ability to use this functionality. You can use it for example to use the 'certchain' argument (which is not supported by the jarsigner plugin) like this:

<arguments>
   <argument>-certchain</argument>
   <argument>${basedir}/src/main/jnlp/foo_chain.pem</argument>
</arguments>
