### PR TITLE
Bugfix for useUniqueVersions in webstart-maven-plugin

### DIFF
--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/AbstractDependencyFilenameStrategy.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/AbstractDependencyFilenameStrategy.java
@@ -51,4 +51,18 @@ public abstract class AbstractDependencyFilenameStrategy
         String extension = artifact.getArtifactHandler().getExtension();
         return extension;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getDependencyFileVersion( Artifact artifact, Boolean useUniqueVersions )
+    {
+        if ( useUniqueVersions != null && useUniqueVersions )
+        {
+            return UniqueVersionsHelper.getUniqueVersion( artifact );
+        }
+
+        return artifact.getVersion();
+    }
+
 }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/DependencyFilenameStrategy.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/DependencyFilenameStrategy.java
@@ -64,4 +64,12 @@ public interface DependencyFilenameStrategy
      */
     String getDependencyFileExtension( Artifact artifact );
 
+    /**
+     * Get the dependency file version for the given artifact.
+     *
+     * @param artifact origin of dependency
+     * @return dependency file version for the given artifact.
+     */
+    String getDependencyFileVersion( Artifact artifact, Boolean useUniqueVersions);
+
 }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/FullDependencyFilenameStrategy.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/FullDependencyFilenameStrategy.java
@@ -60,20 +60,15 @@ public class FullDependencyFilenameStrategy
             {
                 filename += "-";
             }
-            
-            if (useUniqueVersions != null && useUniqueVersions.booleanValue()) 
-            {
-            	filename += artifact.getBaseVersion();
-            }
-            else {
-            	filename += artifact.getVersion();
-            }
+
+            filename += getDependencyFileVersion( artifact, useUniqueVersions );
         }
 
         if ( StringUtils.isNotEmpty( artifact.getClassifier() ) )
         {
             filename += "-" + artifact.getClassifier();
         }
+
         return filename;
     }
 }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/SimpleDependencyFilenameStrategy.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/SimpleDependencyFilenameStrategy.java
@@ -63,15 +63,8 @@ public class SimpleDependencyFilenameStrategy
             {
                 filename += "-";
             }
-            
-            if ( useUniqueVersions != null && useUniqueVersions ) 
-            {
-            	filename += artifact.getBaseVersion();
-            }
-            else 
-            {
-            	filename += artifact.getVersion();
-            }
+
+            filename += getDependencyFileVersion( artifact, useUniqueVersions );
         }
 
         if ( StringUtils.isNotEmpty( artifact.getClassifier() ) )

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/UniqueVersionsHelper.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/UniqueVersionsHelper.java
@@ -22,6 +22,7 @@ package org.codehaus.mojo.webstart.dependency.filenaming;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -39,6 +40,7 @@ public class UniqueVersionsHelper {
             // version is not unique, replace SNAPSHOT with file modification timestamp
             Date d = new Date( artifact.getFile().lastModified() );
             DateFormat df = new SimpleDateFormat( "yyyyMMdd.HHmmss" );
+            df.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
             return m.group( 1 ) + "-" + df.format( d ) + "-0";
         }
         else

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/UniqueVersionsHelper.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/filenaming/UniqueVersionsHelper.java
@@ -1,0 +1,50 @@
+package org.codehaus.mojo.webstart.dependency.filenaming;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.artifact.Artifact;
+
+public class UniqueVersionsHelper {
+
+    private final static Pattern NONUNIQUE_SNAPSHOT_PATTERN = Pattern.compile("^(.*)-SNAPSHOT$");
+
+    public static final String getUniqueVersion( Artifact artifact )
+    {
+        Matcher m = NONUNIQUE_SNAPSHOT_PATTERN.matcher( artifact.getVersion() );
+        if ( m.matches() ) 
+        {
+            // version is not unique, replace SNAPSHOT with file modification timestamp
+            Date d = new Date( artifact.getFile().lastModified() );
+            DateFormat df = new SimpleDateFormat( "yyyyMMdd.HHmmss" );
+            return m.group( 1 ) + "-" + df.format( d ) + "-0";
+        }
+        else
+        {
+            return artifact.getVersion();
+        }
+    }
+
+}

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/generator/AbstractGeneratorExtraConfigWithDeps.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/generator/AbstractGeneratorExtraConfigWithDeps.java
@@ -100,8 +100,16 @@ public abstract class AbstractGeneratorExtraConfigWithDeps
     /**
      * {@inheritDoc}
      */
-    public String getDependencyFilename( Artifact artifact, Boolean outputJarVersion, Boolean useUniqueVersions )
+    public String getDependencyFilename( Artifact artifact, Boolean outputJarVersion )
     {
         return dependencyFilenameStrategy.getDependencyFilename( artifact, outputJarVersion, useUniqueVersions );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getDependencyFileVersion( Artifact artifact )
+    {
+        return dependencyFilenameStrategy.getDependencyFileVersion( artifact, useUniqueVersions );
     }
 }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/generator/Generator.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/generator/Generator.java
@@ -115,25 +115,17 @@ public class Generator
                     buffer.append( jarLibPath ).append( "/" );
                 }
 
-//                    String filename = artifact.getFile().getName();
                 if ( config.isOutputJarVersions() )
                 {
-                    String filename = config.getDependencyFilename( artifact, null, config.isUseUniqueVersions() );
-//                      String extension = filename.substring( filename.lastIndexOf( "." ) );
-//                    buffer.append( artifact.getArtifactId() ).append( extension ).append( "\"" );
+                    String filename = config.getDependencyFilename( artifact, null );
                     buffer.append( filename ).append( "\"" );
-                    if (config.isUseUniqueVersions()) 
-                    {
-                    	buffer.append( " version=\"" ).append( artifact.getBaseVersion() ).append( "\"" );
-                    }
-                    else 
-                    {
-                    	buffer.append( " version=\"" ).append( artifact.getVersion() ).append( "\"" );
-                    }
+
+                    String version = config.getDependencyFileVersion( artifact );
+                    buffer.append( " version=\"" ).append( version ).append( "\"" );
                 }
                 else
                 {
-                    String filename = config.getDependencyFilename( artifact, false, config.isUseUniqueVersions() );
+                    String filename = config.getDependencyFilename( artifact, false );
                     buffer.append( filename ).append( "\"" );
                 }
 

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/generator/GeneratorExtraConfigWithDeps.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/generator/GeneratorExtraConfigWithDeps.java
@@ -39,7 +39,9 @@ public interface GeneratorExtraConfigWithDeps
 
     public String getLibPath();
 
-    String getDependencyFilename( Artifact artifact, Boolean outputJarVersion, Boolean useUniqueVersions );
+    String getDependencyFilename( Artifact artifact, Boolean outputJarVersion );
+
+    String getDependencyFileVersion( Artifact artifact );
 
     boolean isArtifactWithMainClass( Artifact artifact );
 }

--- a/webstart-maven-plugin/src/test/java/org/codehaus/mojo/webstart/generator/GeneratorTest.java
+++ b/webstart-maven-plugin/src/test/java/org/codehaus/mojo/webstart/generator/GeneratorTest.java
@@ -263,7 +263,7 @@ public class GeneratorTest
         		EOL + "<jar href=\"artifact1-1.0-classifier.jar\" main=\"true\"/>" + 
         				EOL + "<jar href=\"artifact2-1.5.jar\"/>" +
         				EOL + "<jar href=\"artifact3-1.5-15012014.121212-1.jar\"/>" +
-        				EOL + "<jar href=\"artifact4-1.5-19700101.010000-0.jar\"/>" + EOL,
+        				EOL + "<jar href=\"artifact4-1.5-19700101.000000-0.jar\"/>" + EOL,
             Generator.getDependenciesText( generatorConfig ) );
 
         GeneratorConfig generatorConfig2 =
@@ -274,7 +274,7 @@ public class GeneratorTest
         				EOL + "<jar href=\"artifact1-classifier.jar\" version=\"1.0\" main=\"true\"/>" +
         				EOL + "<jar href=\"artifact2.jar\" version=\"1.5\"/>"  +
         				EOL + "<jar href=\"artifact3.jar\" version=\"1.5-15012014.121212-1\"/>" +
-        				EOL + "<jar href=\"artifact4.jar\" version=\"1.5-19700101.010000-0\"/>" + EOL,
+        				EOL + "<jar href=\"artifact4.jar\" version=\"1.5-19700101.000000-0\"/>" + EOL,
                       Generator.getDependenciesText( generatorConfig2 ) );
         
         GeneratorConfig generatorConfig3 =
@@ -284,7 +284,7 @@ public class GeneratorTest
             assertEquals( EOL + "<jar href=\"artifact1-1.0-classifier.jar\" main=\"true\"/>" +
             				EOL + "<jar href=\"artifact2-1.5.jar\"/>"  +
             				EOL + "<jar href=\"artifact3-1.5-15012014.121212-1.jar\"/>" +
-            				EOL + "<jar href=\"artifact4-1.5-19700101.010000-0.jar\"/>" + EOL,
+            				EOL + "<jar href=\"artifact4-1.5-19700101.000000-0.jar\"/>" + EOL,
                           Generator.getDependenciesText( generatorConfig3 ) );
     }
 }

--- a/webstart-maven-plugin/src/test/java/org/codehaus/mojo/webstart/generator/GeneratorTest.java
+++ b/webstart-maven-plugin/src/test/java/org/codehaus/mojo/webstart/generator/GeneratorTest.java
@@ -47,6 +47,8 @@ public class GeneratorTest
     protected Artifact artifact2;
 
     protected Artifact artifact3;
+    
+    protected Artifact artifact4;
 
     private List<Artifact> artifacts;
 
@@ -67,16 +69,25 @@ public class GeneratorTest
                                  artifactHandler );
         artifact2.setFile( new File( "artifact2-1.5.jar" ) );
 
-        // add a SNAPSHOT artifact
+        // add a SNAPSHOT artifact, timestamped (from a remote maven repository)
         artifact3 =
                 new DefaultArtifact( "groupId", "artifact3", VersionRange.createFromVersion( "1.5-SNAPSHOT" ), null, "jar", "",
                                      artifactHandler );
-        artifact3.setBaseVersion("1.5-15012014121212");
-        artifact3.setFile( new File( "artifact3-1.5-15012014121212.jar" ) );
+        artifact3.setVersion("1.5-15012014.121212-1");
+        artifact3.setFile( new File( "artifact3-1.5-15012014.121212-1.jar" ) );
+
+        // add a SNAPSHOT artifact, not timestamped (from a local build)
+        artifact4 =
+                new DefaultArtifact( "groupId", "artifact4", VersionRange.createFromVersion( "1.5-SNAPSHOT" ), null, "jar", "",
+                                     artifactHandler );
+        artifact4.setFile( new File( "artifact4-1.5-SNAPSHOT.jar" ) );
+
         artifacts = new ArrayList<Artifact>();
+
         artifacts.add( artifact1 );
         artifacts.add( artifact2 );
         artifacts.add( artifact3 );
+        artifacts.add( artifact4 );
     }
 
     public void testGetDependenciesText()
@@ -99,8 +110,9 @@ public class GeneratorTest
                                  jnlp );
 
         assertEquals( EOL + "<jar href=\"artifact1-1.0-classifier.jar\" main=\"true\"/>" +
-        				EOL + "<jar href=\"artifact2-1.5.jar\"/>" + 
-        				EOL +"<jar href=\"artifact3-1.5-SNAPSHOT.jar\"/>" + EOL,
+        				EOL + "<jar href=\"artifact2-1.5.jar\"/>" +
+        				EOL +"<jar href=\"artifact3-1.5-15012014.121212-1.jar\"/>" +
+        				EOL +"<jar href=\"artifact4-1.5-SNAPSHOT.jar\"/>" + EOL,
             Generator.getDependenciesText( generatorConfig ) );
 
         GeneratorConfig generatorConfig2 =
@@ -109,8 +121,9 @@ public class GeneratorTest
 
         assertEquals( EOL + "<property name=\"jnlp.versionEnabled\" value=\"true\" />" +
         				EOL + "<jar href=\"artifact1-classifier.jar\" version=\"1.0\" main=\"true\"/>" +
-        				EOL + "<jar href=\"artifact2.jar\" version=\"1.5\"/>" + 
-        				EOL +"<jar href=\"artifact3.jar\" version=\"1.5-SNAPSHOT\"/>" + EOL,
+        				EOL + "<jar href=\"artifact2.jar\" version=\"1.5\"/>" +
+        				EOL + "<jar href=\"artifact3.jar\" version=\"1.5-15012014.121212-1\"/>" +
+        				EOL + "<jar href=\"artifact4.jar\" version=\"1.5-SNAPSHOT\"/>" + EOL,
                       Generator.getDependenciesText( generatorConfig2 ) );
     }
 
@@ -134,8 +147,9 @@ public class GeneratorTest
                                  jnlp );
 
         assertEquals( EOL + "<jar href=\"groupId-artifact1-1.0-classifier.jar\" main=\"true\"/>" +
-        				EOL +"<jar href=\"groupId-artifact2-1.5.jar\"/>" + 
-        				EOL +"<jar href=\"groupId-artifact3-1.5-SNAPSHOT.jar\"/>" + EOL,
+        				EOL +"<jar href=\"groupId-artifact2-1.5.jar\"/>" +
+        				EOL +"<jar href=\"groupId-artifact3-1.5-15012014.121212-1.jar\"/>" +
+        				EOL +"<jar href=\"groupId-artifact4-1.5-SNAPSHOT.jar\"/>" + EOL,
                       Generator.getDependenciesText( generatorConfig ) );
 
         GeneratorConfig generatorConfig2 =
@@ -144,8 +158,9 @@ public class GeneratorTest
 
         assertEquals( EOL + "<property name=\"jnlp.versionEnabled\" value=\"true\" />" +
         				EOL + "<jar href=\"groupId-artifact1-classifier.jar\" version=\"1.0\" main=\"true\"/>" +
-        				EOL + "<jar href=\"groupId-artifact2.jar\" version=\"1.5\"/>" + 
-        				EOL +"<jar href=\"groupId-artifact3.jar\" version=\"1.5-SNAPSHOT\"/>" + EOL,
+        				EOL + "<jar href=\"groupId-artifact2.jar\" version=\"1.5\"/>" +
+        				EOL + "<jar href=\"groupId-artifact3.jar\" version=\"1.5-15012014.121212-1\"/>" +
+        				EOL + "<jar href=\"groupId-artifact4.jar\" version=\"1.5-SNAPSHOT\"/>" + EOL,
                       Generator.getDependenciesText( generatorConfig2 ) );
     }
 
@@ -171,7 +186,8 @@ public class GeneratorTest
         assertEquals( EOL + "<property name=\"jnlp.packEnabled\" value=\"true\" />" +
         				EOL + "<jar href=\"artifact1-1.0-classifier.jar\" main=\"true\"/>" +
         				EOL + "<jar href=\"artifact2-1.5.jar\"/>" + 
-        				EOL +"<jar href=\"artifact3-1.5-SNAPSHOT.jar\"/>" + EOL, Generator.getDependenciesText( generatorConfig ) );
+        				EOL +"<jar href=\"artifact3-1.5-15012014.121212-1.jar\"/>" +
+        				EOL +"<jar href=\"artifact4-1.5-SNAPSHOT.jar\"/>" + EOL, Generator.getDependenciesText( generatorConfig ) );
 
         GeneratorConfig generatorConfig2 =
             new GeneratorConfig( null, true, true, false, artifact1, dependencyFilenameStrategy, artifacts, null, codebase,
@@ -181,7 +197,8 @@ public class GeneratorTest
         				EOL + "<property name=\"jnlp.versionEnabled\" value=\"true\" />" +
         				EOL + "<jar href=\"artifact1-classifier.jar\" version=\"1.0\" main=\"true\"/>" +
         				EOL + "<jar href=\"artifact2.jar\" version=\"1.5\"/>" + 
-        				EOL +"<jar href=\"artifact3.jar\" version=\"1.5-SNAPSHOT\"/>" + EOL,
+        				EOL +"<jar href=\"artifact3.jar\" version=\"1.5-15012014.121212-1\"/>" +
+        				EOL +"<jar href=\"artifact4.jar\" version=\"1.5-SNAPSHOT\"/>" + EOL,
                       Generator.getDependenciesText( generatorConfig2 ) );
     }
 
@@ -205,8 +222,10 @@ public class GeneratorTest
                                  jnlp );
 
         assertEquals( EOL + "<jar href=\"lib/artifact1-1.0-classifier.jar\" main=\"true\"/>" +
-        				EOL + "<jar href=\"lib/artifact2-1.5.jar\"/>" + 
-        				EOL +"<jar href=\"lib/artifact3-1.5-SNAPSHOT.jar\"/>" + EOL,
+        				EOL + "<jar href=\"lib/artifact2-1.5.jar\"/>" +
+        				EOL +"<jar href=\"lib/artifact3-1.5-15012014.121212-1.jar\"/>" +
+        				EOL +"<jar href=\"lib/artifact4-1.5-SNAPSHOT.jar\"/>" + EOL,
+
                       Generator.getDependenciesText( generatorConfig ) );
 
         GeneratorConfig generatorConfig2 =
@@ -215,8 +234,9 @@ public class GeneratorTest
 
         assertEquals( EOL + "<property name=\"jnlp.versionEnabled\" value=\"true\" />" +
         				EOL + "<jar href=\"lib/artifact1-classifier.jar\" version=\"1.0\" main=\"true\"/>" +
-        				EOL + "<jar href=\"lib/artifact2.jar\" version=\"1.5\"/>" + 
-        				EOL +"<jar href=\"lib/artifact3.jar\" version=\"1.5-SNAPSHOT\"/>" + EOL,
+        				EOL + "<jar href=\"lib/artifact2.jar\" version=\"1.5\"/>" +
+        				EOL +"<jar href=\"lib/artifact3.jar\" version=\"1.5-15012014.121212-1\"/>" +
+        				EOL +"<jar href=\"lib/artifact4.jar\" version=\"1.5-SNAPSHOT\"/>" + EOL,
                       Generator.getDependenciesText( generatorConfig2 ) );
     }
     
@@ -240,8 +260,10 @@ public class GeneratorTest
                                  jnlp );
 
         assertEquals(
-        		EOL + "<jar href=\"artifact1-1.0-classifier.jar\" main=\"true\"/>" + EOL + "<jar href=\"artifact2-1.5.jar\"/>" +
-        				EOL + "<jar href=\"artifact3-1.5-15012014121212.jar\"/>" + EOL,
+        		EOL + "<jar href=\"artifact1-1.0-classifier.jar\" main=\"true\"/>" + 
+        				EOL + "<jar href=\"artifact2-1.5.jar\"/>" +
+        				EOL + "<jar href=\"artifact3-1.5-15012014.121212-1.jar\"/>" +
+        				EOL + "<jar href=\"artifact4-1.5-19700101.010000-0.jar\"/>" + EOL,
             Generator.getDependenciesText( generatorConfig ) );
 
         GeneratorConfig generatorConfig2 =
@@ -251,7 +273,8 @@ public class GeneratorTest
         assertEquals( EOL + "<property name=\"jnlp.versionEnabled\" value=\"true\" />" +
         				EOL + "<jar href=\"artifact1-classifier.jar\" version=\"1.0\" main=\"true\"/>" +
         				EOL + "<jar href=\"artifact2.jar\" version=\"1.5\"/>"  +
-        				EOL + "<jar href=\"artifact3.jar\" version=\"1.5-15012014121212\"/>" + EOL,
+        				EOL + "<jar href=\"artifact3.jar\" version=\"1.5-15012014.121212-1\"/>" +
+        				EOL + "<jar href=\"artifact4.jar\" version=\"1.5-19700101.010000-0\"/>" + EOL,
                       Generator.getDependenciesText( generatorConfig2 ) );
         
         GeneratorConfig generatorConfig3 =
@@ -260,7 +283,8 @@ public class GeneratorTest
 
             assertEquals( EOL + "<jar href=\"artifact1-1.0-classifier.jar\" main=\"true\"/>" +
             				EOL + "<jar href=\"artifact2-1.5.jar\"/>"  +
-            				EOL + "<jar href=\"artifact3-1.5-15012014121212.jar\"/>" + EOL,
+            				EOL + "<jar href=\"artifact3-1.5-15012014.121212-1.jar\"/>" +
+            				EOL + "<jar href=\"artifact4-1.5-19700101.010000-0.jar\"/>" + EOL,
                           Generator.getDependenciesText( generatorConfig3 ) );
-    }    
+    }
 }


### PR DESCRIPTION
This branch contains a proposed Bugfix when enabling useUniqueVersions. The generated versions in the JNLP file where not always unique for snapshots. It was still possible to have -SNAPSHOT versions there, even if useUniqueVersions was set to true. This results in problems when deploying a new version of the webstart application, because newly built JARs do not get downloaded by the client due to webstart caching.

The Fix now makes sure that there are no -SNAPSHOT versions in generated JNLP files. If needed, a timestamped version is generated based on the file modification date of the artifact. This might be necessary for locally built snapshots that have no timestamped maven snapshot version.
