### PR TITLE
Added hook for JnlpFileHandler

### DIFF
--- a/webstart-jnlp-servlet/src/main/java/jnlp/sample/servlet/JnlpFileHandler.java
+++ b/webstart-jnlp-servlet/src/main/java/jnlp/sample/servlet/JnlpFileHandler.java
@@ -60,6 +60,7 @@ import java.net.URLConnection;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 
 /* The JNLP file handler implements a class that keeps
@@ -73,6 +74,8 @@ public class JnlpFileHandler
 
     private ServletContext _servletContext;
 
+    private JnlpFileHandlerHook _hook;
+
     private Logger _log = null;
 
     private HashMap _jnlpFiles = null;
@@ -83,9 +86,10 @@ public class JnlpFileHandler
      * @param log            TODO
      * @param servletContext TODO
      */
-    public JnlpFileHandler( ServletContext servletContext, Logger log )
+    public JnlpFileHandler( ServletContext servletContext, JnlpFileHandlerHook hook, Logger log )
     {
         _servletContext = servletContext;
+        _hook = hook;
         _log = log;
         _jnlpFiles = new HashMap();
     }
@@ -293,6 +297,7 @@ public class JnlpFileHandler
                             }
                         }
                     }
+                    _hook.preCommit( dreq, document );
                     TransformerFactory tFactory = TransformerFactory.newInstance();
                     Transformer transformer = tFactory.newTransformer();
                     DOMSource source = new DOMSource( document );

--- a/webstart-jnlp-servlet/src/main/java/jnlp/sample/servlet/JnlpFileHandlerHook.java
+++ b/webstart-jnlp-servlet/src/main/java/jnlp/sample/servlet/JnlpFileHandlerHook.java
@@ -1,0 +1,28 @@
+package jnlp.sample.servlet;
+
+import org.w3c.dom.Document;
+
+/**
+ * Hook for JNLP file request
+ */
+public interface JnlpFileHandlerHook {
+
+    /**
+     * Identity implementation
+     */
+    public static final JnlpFileHandlerHook IDENTITY = new JnlpFileHandlerHook() {
+	@Override
+	public void preCommit(DownloadRequest dreq, Document document) {
+	}
+    };
+
+    /**
+     * Invoked before the HTTP response of a JNLP file is committed.
+     * 
+     * @param dreq
+     *            original request
+     * @param document
+     *            JNLP document to be committed
+     */
+    void preCommit(DownloadRequest dreq, Document document);
+}

--- a/webstart-jnlp-servlet/src/main/resources/jnlp/sample/servlet/resources/strings.properties
+++ b/webstart-jnlp-servlet/src/main/resources/jnlp/sample/servlet/resources/strings.properties
@@ -48,6 +48,7 @@ servlet.log.warning.xml.missing-pattern=Missing <pattern> element in {0}
 servlet.log.warning.xml.missing-elems=Missing <version-id> or <file> attribute in {0}
 servlet.log.warning.xml.missing-elems2=Missing <version-id>, <file>, or <product-version-id> attribute in {0}
 servlet.log.warning.jardiff.failed=Failed to generate JarDiff for {0} {1}->{2}
+servlet.log.warning.failed-jnlp-file-hook=Failed to load implementing class for JnlpPostProcessor: {0}
 
 # Informational
 servlet.log.info.request=Request: {0}


### PR DESCRIPTION
It allows to configure a hook to JnlpFileHandler, invoked before the HTTP response of a JNLP file request is committed.
The hook implementation could manipulate the JNLP DOM model, for example to set <argument> elements based on HTTP query params.