### PR TITLE
Filename in version.xml not correct for test-jar's

### DIFF
--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/generator/VersionXmlGenerator.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/generator/VersionXmlGenerator.java
@@ -133,7 +133,7 @@ public class VersionXmlGenerator
             writer.newLine();
             writer.write( "    <file>" );
             writer.write( String.format( "%s-%s%s.%s", jarResource.getArtifactId(), jarResource.getVersion(),
-                                         jarResource.getClassifier() == null ? "" : "-" + jarResource.getClassifier(), jarResource.getType() ) );
+                                         jarResource.getClassifier() == null ? "" : "-" + jarResource.getClassifier(), "test-jar".equals(jarResource.getType()) ? "jar" : jarResource.getType() ) );
             writer.write( "</file>" );
             writer.newLine();
             writer.write( "  </resource>" );


### PR DESCRIPTION
When the resource artifact is of type "**test-jar**" the artifact file extension must be "**jar**" (not "test-jar", so jarResource.getType() can't be used directly as filename extension).

This relates to: #6 and #42 