### PR TITLE
Certificate chain support, Apache Commons Compress support and Skipping of INDEX.LIST

### DIFF
--- a/webstart-maven-plugin/pom.xml
+++ b/webstart-maven-plugin/pom.xml
@@ -47,6 +47,13 @@
   <dependencies>
 
 	<dependency>
+	  <groupId> org.apache.commons</groupId>
+	  <artifactId>commons-compress</artifactId>
+          <version>1.24.0</version>
+	</dependency>
+
+
+	<dependency>
 	  <groupId>org.codehaus.mojo</groupId>
 	  <artifactId>keytool-api-1.7</artifactId>
 	</dependency>

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/AbstractBaseJnlpMojo.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/AbstractBaseJnlpMojo.java
@@ -408,6 +408,17 @@ public abstract class AbstractBaseJnlpMojo
     }
 
     /**
+     * Returns the flag that indicates whether or not jar resources
+     * will be compressed using the Apache Commons Compress pack200 variant.
+     *
+     * @return Returns the value of the pack200.enabled field.
+     */
+    public boolean isCommonsCompressEnabled()
+    {
+        return pack200 != null && pack200.isCommonsCompressEnabled();
+    }
+
+    /**
      * Returns the files to be passed without pack200 compression.
      *
      * @return Returns the list value of the pack200.passFiles.
@@ -691,7 +702,7 @@ public abstract class AbstractBaseJnlpMojo
 
                 // http://java.sun.com/j2se/1.5.0/docs/guide/deployment/deployment-guide/pack200.html
                 // we need to pack then unpack the files before signing them
-                unpackJars( getLibDirectory() );
+                unpackJars( getLibDirectory(), isCommonsCompressEnabled() );
 
                 // As out current Pack200 ant tasks don't give us the ability to use a temporary area for
                 // creating those temporary packing, we have to delete the temporary files.
@@ -733,7 +744,7 @@ public abstract class AbstractBaseJnlpMojo
     {
         try
         {
-            getPack200Tool().packJars( directory, filter, isGzip(), getPack200PassFiles() );
+            getPack200Tool().packJars( directory, filter, isGzip(), getPack200PassFiles(), isCommonsCompressEnabled() );
         }
         catch ( IOException e )
         {
@@ -798,7 +809,7 @@ public abstract class AbstractBaseJnlpMojo
     // Private Methods
     // ----------------------------------------------------------------------
 
-    private void unpackJars( File directory )
+    private void unpackJars( File directory, boolean commonsCompress )
             throws MojoExecutionException
     {
         getLog().info( "-- Unpack jars before sign operation " );
@@ -812,7 +823,7 @@ public abstract class AbstractBaseJnlpMojo
         // then unpack
         try
         {
-            getPack200Tool().unpackJars( directory, unprocessedPack200FileFilter );
+            getPack200Tool().unpackJars( directory, unprocessedPack200FileFilter, commonsCompress );
         }
         catch ( IOException e )
         {

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/AbstractJnlpMojo.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/AbstractJnlpMojo.java
@@ -827,6 +827,7 @@ public abstract class AbstractJnlpMojo
         getLog().debug( "basedir " + this.basedir );
         getLog().debug( "gzip " + isGzip() );
         getLog().debug( "pack200 " + isPack200() );
+        getLog().debug( "Commons Compress pack200 " + isCommonsCompressEnabled() );
         getLog().debug( "project " + this.getProject() );
         getLog().debug( "verbose " + isVerbose() );
 

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/JnlpDependencyConfig.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/JnlpDependencyConfig.java
@@ -114,6 +114,17 @@ public class JnlpDependencyConfig
     }
 
     /**
+     * Returns the flag that indicates whether or not jar resources
+     * will be compressed using pack200.
+     *
+     * @return Returns the value of the pack200.enabled field.
+     */
+    public boolean isCommonsCompressEnabled()
+    {
+        return globalConfig.isCommonsCompressEnabled();
+    }
+
+    /**
      * Returns the files to be passed without pack200 compression.
      *
      * @return Returns the list value of the pack200.passFiles.

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/JnlpDependencyGlobalConfig.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/JnlpDependencyGlobalConfig.java
@@ -153,4 +153,10 @@ public class JnlpDependencyGlobalConfig
     {
         return pack200 != null && pack200.isEnabled();
     }
+
+
+    public boolean isCommonsCompressEnabled()
+    {
+        return pack200 != null && pack200.isCommonsCompressEnabled();
+    }
 }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/task/Pack200Task.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/task/Pack200Task.java
@@ -78,7 +78,7 @@ public class Pack200Task
         verboseLog( config, "Pack200 file: " + file );
         try
         {
-            File result = pack200Tool.packJar( file, config.isGzip(), config.getPack200PassFiles() );
+            File result = pack200Tool.packJar( file, config.isGzip(), config.getPack200PassFiles(), config.isCommonsCompressEnabled() );
             getLogger().debug( "packed200 file: " + result );
             return result;
         }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/task/UnPack200Task.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/task/UnPack200Task.java
@@ -87,7 +87,7 @@ public class UnPack200Task
         verboseLog( config, "Unpack 200 file: " + file );
         try
         {
-            File result = pack200Tool.unpackJar( file );
+            File result = pack200Tool.unpackJar( file, config.isCommonsCompressEnabled() );
             getLogger().debug( "Unpacked 200 file: " + result );
             return result;
         }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/task/UpdateManifestTask.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/dependency/task/UpdateManifestTask.java
@@ -49,6 +49,9 @@ import java.util.zip.ZipFile;
 public class UpdateManifestTask
         extends AbstractJnlpTask
 {
+
+    private static final String INDEX_LIST = "META-INF/INDEX.LIST";
+
     public static final String ROLE_HINT = "UpdateManifestTask";
 
     @Requirement
@@ -121,6 +124,11 @@ public class UpdateManifestTask
 
                 // skip the original manifest
                 if ( JarFile.MANIFEST_NAME.equals( entry.getName() ) )
+                {
+                    continue;
+                }
+                //skip the INDEX.LIST file
+                if (INDEX_LIST.equals(entry.getName()))
                 {
                     continue;
                 }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/pack200/Pack200Config.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/pack200/Pack200Config.java
@@ -40,6 +40,13 @@ public class Pack200Config
     private boolean enabled;
 
     /**
+     * Whether the commons compress version of pack200 is enabled
+     *
+     * @see #isCommonsCompressEnabled()
+     */
+    private boolean commonsCompressEnabled;
+
+    /**
      * The files to be passed without compression.
      *
      * @see #getPassFiles()
@@ -82,5 +89,13 @@ public class Pack200Config
     {
         this.passFiles = passFiles;
     }
+
+	public boolean isCommonsCompressEnabled() {
+		return commonsCompressEnabled;
+	}
+
+	public void setCommonsCompressEnabled(boolean commonsCompressEnabled) {
+		this.commonsCompressEnabled = commonsCompressEnabled;
+	}
 
 }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/pack200/Pack200Tool.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/pack200/Pack200Tool.java
@@ -58,7 +58,7 @@ public interface Pack200Tool
      * @param gzip        true if the destination file
      * @throws IOException TODO
      */
-    void pack( File source, File destination, Map<String, String> props, boolean gzip )
+    void pack( File source, File destination, Map<String, String> props, boolean gzip, boolean commonsCompress )
             throws IOException;
 
     /**
@@ -69,7 +69,7 @@ public interface Pack200Tool
      * @param props       the packing properties
      * @throws IOException TODO
      */
-    void repack( File source, File destination, Map<String, String> props )
+    void repack( File source, File destination, Map<String, String> props, boolean commonsCompress )
             throws IOException;
 
     /**
@@ -80,7 +80,7 @@ public interface Pack200Tool
      * @param props       the packing properties
      * @throws IOException TODO
      */
-    void unpack( File source, File destination, Map<String, String> props )
+    void unpack( File source, File destination, Map<String, String> props, boolean commonsCompress )
             throws IOException;
 
     /**
@@ -94,7 +94,7 @@ public interface Pack200Tool
      * @param passFiles     the list of file names to be passed as not pack200 compressed
      * @throws IOException TODO
      */
-    void packJars( File directory, FileFilter jarFileFilter, boolean gzip, List<String> passFiles )
+    void packJars( File directory, FileFilter jarFileFilter, boolean gzip, List<String> passFiles, boolean commonsCompress )
             throws IOException;
 
     /**
@@ -106,7 +106,7 @@ public interface Pack200Tool
      * @return the packed file
      * @throws IOException TODO
      */
-    File packJar( File jarFile, boolean gzip, List<String> passFiles )
+    File packJar( File jarFile, boolean gzip, List<String> passFiles, boolean commonsCompress )
             throws IOException;
 
     /**
@@ -116,7 +116,7 @@ public interface Pack200Tool
      * @param pack200FileFilter the fileter to determin which files to unpakc
      * @throws IOException TODO
      */
-    void unpackJars( File directory, FileFilter pack200FileFilter )
+    void unpackJars( File directory, FileFilter pack200FileFilter, boolean commonsCompress )
             throws IOException;
 
     /**
@@ -126,6 +126,6 @@ public interface Pack200Tool
      * @return the unpacked file
      * @throws IOException TODO
      */
-    File unpackJar( File packFile )
+    File unpackJar( File packFile, boolean commonsCompress )
             throws IOException;
 }

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/sign/SignConfig.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/sign/SignConfig.java
@@ -65,6 +65,8 @@ public class SignConfig
      */
     private File workingKeystore;
 
+    private File certchain;
+
     /**
      */
     private String keyalg;
@@ -331,6 +333,7 @@ public class SignConfig
         request.setTsaLocation( getTsaLocation() );
         request.setProviderArg( getProviderArg() );
         request.setProviderClass( getProviderClass() );
+        request.setCertchain( getCertchain() );
 
         // Special handling for passwords through the Maven Security Dispatcher
         request.setKeypass( decrypt( keypass ) );
@@ -707,6 +710,14 @@ public class SignConfig
         this.providerClass = providerClass;
     }
 
+    public File getCertchain() {
+        return certchain;
+    }
+
+    public void setCertchain(File certchain) {
+        this.certchain = certchain;
+    }
+    
     private void appendToDnameBuffer( final String property, StringBuffer buffer, final String prefix )
     {
         if ( property != null )

--- a/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/util/DefaultJarUtil.java
+++ b/webstart-maven-plugin/src/main/java/org/codehaus/mojo/webstart/util/DefaultJarUtil.java
@@ -49,7 +49,9 @@ public class DefaultJarUtil
         implements JarUtil
 {
 
-    /**
+    private static final String INDEX_LIST = "META-INF/INDEX.LIST";
+
+	/**
      * io helper.
      */
     @Requirement
@@ -80,6 +82,11 @@ public class DefaultJarUtil
 
                 // skip the original manifest
                 if ( JarFile.MANIFEST_NAME.equals( entry.getName() ) )
+                {
+                    continue;
+                }
+                //skip the INDEX.LIST file
+                if (INDEX_LIST.equals(entry.getName()))
                 {
                     continue;
                 }


### PR DESCRIPTION
This pull requests provides some code changes that may be of use, which is to enable the certchain jarsigner argument, which is useful when signing with hardware tokens.  Additionally, it includes a change to skip the INDEX.LIST file, which prior to the change implicitly results in failed jar downloads when using .pack.gz resources only.  Furthermore it adds configurable support for the Apache Commons Compress Pack200 algorithm that may be used to reinstate the pack200 feature that has been removed in newer versions of the JDK.